### PR TITLE
Remove obsolete version attribute from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.13"
-   
 services:
   db:
     image: mysql:8.0


### PR DESCRIPTION
Removed the deprecated version attribute to comply with modern Docker Compose V2 standards and eliminate the startup warning.